### PR TITLE
Feature/OL40-todo_create - fixes

### DIFF
--- a/todo_list/tests.py
+++ b/todo_list/tests.py
@@ -1,10 +1,9 @@
-from django.test import Client, TestCase
+from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from model_bakery import baker
-import requests
 
 from todo_list.models import TodoList
 
@@ -17,8 +16,7 @@ class TodoListTests(TestCase):
         self.url = reverse("todo_list:todo_list")
 
     def test_list_todo_lists_requires_authorization(self):
-        client = Client()
-        response = client.get(path=self.url)
+        response = self.client.get(path=self.url)
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_list_todo_lists(self):
@@ -33,10 +31,10 @@ class TodoListTests(TestCase):
         # Authenticate user
         token, created = Token.objects.get_or_create(user=user)
         self.assertTrue(created)
-        client = Client(HTTP_AUTHORIZATION="Token " + token.key)
+        headers = {"HTTP_AUTHORIZATION": "Token " + token.key}
 
         # Client asks for todo lists successfully
-        response = client.get(path=self.url)
+        response = self.client.get(path=self.url, **headers)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.data))
         self.assertEqual(todo_list.title, response.data[0]["title"])
@@ -55,12 +53,29 @@ class TodoListTests(TestCase):
         # Authenticate 'user_2'
         token, created = Token.objects.get_or_create(user=user_2)
         self.assertTrue(created)
-        client = Client(HTTP_AUTHORIZATION="Token " + token.key)
+        headers = {"HTTP_AUTHORIZATION": "Token " + token.key}
 
         # Client asks for todo lists, none should be available
-        response = client.get(path=self.url)
+        response = self.client.get(path=self.url, **headers)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, len(response.data))
+
+    def test_create_todo_list_requires_data(self):
+        # Create user
+        user = baker.make("User")
+        self.assertEqual(1, User.objects.count())
+
+        # Authenticate user
+        token, created = Token.objects.get_or_create(user=user)
+        self.assertTrue(created)
+        headers = {"HTTP_AUTHORIZATION": "Token " + token.key}
+
+        # Try to create list passing no 'title' as data, results in bad request
+        response = self.client.post(
+            path=self.url, content_type="application/json", **headers
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual("required", response.data["title"][0].code)
 
     def test_create_todo_list(self):
         # Create user
@@ -70,14 +85,19 @@ class TodoListTests(TestCase):
         # Authenticate user
         token, created = Token.objects.get_or_create(user=user)
         self.assertTrue(created)
-        client = Client(HTTP_AUTHORIZATION="Token " + token.key)
+        headers = {"HTTP_AUTHORIZATION": "Token " + token.key}
 
         # Client creates todo list successfully
-        todo_list_sample = {"title": baker.prepare("TodoList").title, "owner": user.pk}
-        response = client.post(
-            path=self.url, content_type="application/json", data=todo_list_sample
+        self.assertEqual(0, TodoList.objects.count())
+        todo_list_sample = {"title": "This is a sample title for a To-Do List"}
+        response = self.client.post(
+            path=self.url,
+            content_type="application/json",
+            data=todo_list_sample,
+            **headers
         )
+        todo_list_created = TodoList.objects.get()
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
-        self.assertEqual(1, TodoList.objects.count())
-        self.assertEqual(todo_list_sample["title"], TodoList.objects.get(id=1).title)
-        self.assertEqual(todo_list_sample["owner"], TodoList.objects.get(id=1).owner.pk)
+        self.assertEqual(1, response.data["id"])
+        self.assertEqual(todo_list_sample["title"], todo_list_created.title)
+        self.assertEqual(user.id, todo_list_created.owner.pk)

--- a/todo_list/tests.py
+++ b/todo_list/tests.py
@@ -75,6 +75,7 @@ class TodoListTests(TestCase):
             path=self.url, content_type="application/json", **headers
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(1, len(response.data))
         self.assertEqual("required", response.data["title"][0].code)
 
     def test_create_todo_list(self):

--- a/todo_list/tests.py
+++ b/todo_list/tests.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from model_bakery import baker
+import requests
 
 from todo_list.models import TodoList
 
@@ -13,18 +14,59 @@ User = get_user_model()
 class TodoListTests(TestCase):
     def setUp(self):
         # Route
-        self.url = reverse("dashboard")
+        self.url = reverse("todo_list:todo_list")
         # Header
         self.content_type = "application/json"
 
+    def test_list_todo_lists(self):
+        # Create user
+        user = User.objects.create_user(baker.prepare("User"))
+        self.assertEqual(1, User.objects.count())
+
+        # Create todo list
+        todo_list = TodoList.objects.create(
+            title=baker.prepare("TodoList").title,
+            owner=user
+        )
+        self.assertEqual(1, TodoList.objects.count())
+
+        # Authenticate user
+        token, created = Token.objects.get_or_create(user=user)
+        self.assertTrue(created)
+        client = Client(HTTP_AUTHORIZATION="Token " + token.key)
+
+        # Client asks for todo lists
+        response = client.get(path=self.url)
+        self.assertEqual(1, len(response.data))
+        self.assertEqual(todo_list.title, response.data[0]["title"])
+        self.assertEqual(todo_list.owner.pk, response.data[0]["owner"])
+
+    def test_list_todo_lists_is_private(self):
+        # Create two distinct users
+        user_1 = User.objects.create_user(baker.prepare("User"))
+        user_2 = User.objects.create_user(baker.prepare("User"))
+        self.assertEqual(2, User.objects.count())
+
+        # Create todo list with user_1 as owner
+        todo_list = TodoList.objects.create(
+            title=baker.prepare("TodoList").title,
+            owner=user_1
+        )
+        self.assertEqual(1, TodoList.objects.count())
+
+        # Authenticate user_2
+        token, created = Token.objects.get_or_create(user=user_2)
+        self.assertTrue(created)
+        client = Client(HTTP_AUTHORIZATION="Token " + token.key)
+
+        # Client asks for todo lists, none should be available
+        response = client.get(path=self.url)
+        self.assertEqual(0, len(response.data))
+
+
     def test_create_todo_list(self):
         # Create user
-        user_sample = baker.prepare("User")
-        user = User.objects.create_user(
-            username=user_sample.username,
-            email=user_sample.email,
-            password=user_sample.password,
-        )
+        user = User.objects.create_user(baker.prepare("User"))
         self.assertEqual(1, User.objects.count())
 
         # Authenticate user
@@ -32,9 +74,16 @@ class TodoListTests(TestCase):
         self.assertTrue(created)
         client = Client(HTTP_AUTHORIZATION="Token " + token.key)
 
-        # Create todo list
-        data = {"title": baker.prepare("TodoList").title, "owner": user.pk}
-        client.post(path=self.url, content_type=self.content_type, data=data)
+        # Client creates todo list
+        todo_list_sample = {
+            "title": baker.prepare("TodoList").title,
+            "owner": user.pk
+        }
+        client.post(
+            path=self.url,
+            content_type=self.content_type,
+            data=todo_list_sample
+        )
         self.assertEqual(1, TodoList.objects.count())
-        self.assertEqual(data["title"], TodoList.objects.get(id=1).title)
-        self.assertEqual(data["owner"], TodoList.objects.get(id=1).owner.pk)
+        self.assertEqual(todo_list_sample["title"], TodoList.objects.get(id=1).title)
+        self.assertEqual(todo_list_sample["owner"], TodoList.objects.get(id=1).owner.pk)

--- a/todo_list/tests.py
+++ b/todo_list/tests.py
@@ -23,13 +23,11 @@ class TodoListTests(TestCase):
 
     def test_list_todo_lists(self):
         # Create user
-        user = User.objects.create_user(baker.prepare("User"))
+        user = baker.make("User")
         self.assertEqual(1, User.objects.count())
 
         # Create todo list
-        todo_list = TodoList.objects.create(
-            title=baker.prepare("TodoList").title, owner=user
-        )
+        todo_list = baker.make("TodoList", owner=user)
         self.assertEqual(1, TodoList.objects.count())
 
         # Authenticate user
@@ -46,15 +44,15 @@ class TodoListTests(TestCase):
 
     def test_list_todo_lists_is_private(self):
         # Create two distinct users
-        user_1 = User.objects.create_user(baker.prepare("User"))
-        user_2 = User.objects.create_user(baker.prepare("User"))
+        user_1 = baker.make("User")
+        user_2 = baker.make("User")
         self.assertEqual(2, User.objects.count())
 
-        # Create todo list with user_1 as owner
-        TodoList.objects.create(title=baker.prepare("TodoList").title, owner=user_1)
+        # Create todo list with 'user_1' as owner
+        baker.make("TodoList", owner=user_1)
         self.assertEqual(1, TodoList.objects.count())
 
-        # Authenticate user_2
+        # Authenticate 'user_2'
         token, created = Token.objects.get_or_create(user=user_2)
         self.assertTrue(created)
         client = Client(HTTP_AUTHORIZATION="Token " + token.key)
@@ -66,7 +64,7 @@ class TodoListTests(TestCase):
 
     def test_create_todo_list(self):
         # Create user
-        user = User.objects.create_user(baker.prepare("User"))
+        user = baker.make("User")
         self.assertEqual(1, User.objects.count())
 
         # Authenticate user

--- a/todo_list/tests.py
+++ b/todo_list/tests.py
@@ -15,8 +15,11 @@ class TodoListTests(TestCase):
     def setUp(self):
         # Route
         self.url = reverse("todo_list:todo_list")
-        # Header
-        self.content_type = "application/json"
+
+    def test_list_todo_lists_requires_authorization(self):
+        client = Client()
+        response = client.get(path=self.url)
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_list_todo_lists(self):
         # Create user
@@ -25,8 +28,7 @@ class TodoListTests(TestCase):
 
         # Create todo list
         todo_list = TodoList.objects.create(
-            title=baker.prepare("TodoList").title,
-            owner=user
+            title=baker.prepare("TodoList").title, owner=user
         )
         self.assertEqual(1, TodoList.objects.count())
 
@@ -35,8 +37,9 @@ class TodoListTests(TestCase):
         self.assertTrue(created)
         client = Client(HTTP_AUTHORIZATION="Token " + token.key)
 
-        # Client asks for todo lists
+        # Client asks for todo lists successfully
         response = client.get(path=self.url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.data))
         self.assertEqual(todo_list.title, response.data[0]["title"])
         self.assertEqual(todo_list.owner.pk, response.data[0]["owner"])
@@ -48,10 +51,7 @@ class TodoListTests(TestCase):
         self.assertEqual(2, User.objects.count())
 
         # Create todo list with user_1 as owner
-        todo_list = TodoList.objects.create(
-            title=baker.prepare("TodoList").title,
-            owner=user_1
-        )
+        TodoList.objects.create(title=baker.prepare("TodoList").title, owner=user_1)
         self.assertEqual(1, TodoList.objects.count())
 
         # Authenticate user_2
@@ -61,8 +61,8 @@ class TodoListTests(TestCase):
 
         # Client asks for todo lists, none should be available
         response = client.get(path=self.url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, len(response.data))
-
 
     def test_create_todo_list(self):
         # Create user
@@ -74,16 +74,12 @@ class TodoListTests(TestCase):
         self.assertTrue(created)
         client = Client(HTTP_AUTHORIZATION="Token " + token.key)
 
-        # Client creates todo list
-        todo_list_sample = {
-            "title": baker.prepare("TodoList").title,
-            "owner": user.pk
-        }
-        client.post(
-            path=self.url,
-            content_type=self.content_type,
-            data=todo_list_sample
+        # Client creates todo list successfully
+        todo_list_sample = {"title": baker.prepare("TodoList").title, "owner": user.pk}
+        response = client.post(
+            path=self.url, content_type="application/json", data=todo_list_sample
         )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(1, TodoList.objects.count())
         self.assertEqual(todo_list_sample["title"], TodoList.objects.get(id=1).title)
         self.assertEqual(todo_list_sample["owner"], TodoList.objects.get(id=1).owner.pk)

--- a/todo_list/urls.py
+++ b/todo_list/urls.py
@@ -4,5 +4,5 @@ from rest_framework import routers
 from .views import TodoListAPIView
 
 urlpatterns = [
-    path("", TodoListAPIView.as_view(), name="dashboard"),
+    path("", TodoListAPIView.as_view(), name="todo_list"),
 ]

--- a/todo_list/urls.py
+++ b/todo_list/urls.py
@@ -3,6 +3,7 @@ from rest_framework import routers
 
 from .views import TodoListAPIView
 
+app_name = "todo_list"
 urlpatterns = [
     path("", TodoListAPIView.as_view(), name="todo_list"),
 ]

--- a/todo_list/views.py
+++ b/todo_list/views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets, permissions, generics, status
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
 from .models import TodoList
 from .serializers import TodoListSerializer
@@ -7,10 +8,11 @@ from .serializers import TodoListSerializer
 
 class TodoListAPIView(generics.ListCreateAPIView):
     serializer_class = TodoListSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
-        return reversed(TodoList.objects.filter(owner=user))
+        return TodoList.objects.filter(owner=user).order_by("-id")
 
     def create(self, request, *args, **kwargs):
         data = request.data


### PR DESCRIPTION
**Link to task:**
https://labcodes.atlassian.net/browse/OL-40

**How to test:**
- Run `python manage.py test`, check if all tests pass. 

**Description of your solution:**
After merging PR#7, we noticed tests for the `todo_list` API were missing. This PR introduce new tests for the `TodoListAPIView`. As a corollary, `permission_classes` were added to this view.